### PR TITLE
Upgrade to using markdown2 as MD to HTML parser

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -40,8 +40,6 @@ def convert_code_block(html):
             content = re.search(r'<pre><code.*?>(.*?)</code></pre>', tag, re.DOTALL).group(1)
             content = '<ac:plain-text-body><![CDATA[' + content + ']]></ac:plain-text-body>'
             conf_ml = conf_ml + content + '</ac:structured-macro>'
-            conf_ml = conf_ml.replace('&lt;', '<').replace('&gt;', '>')
-            conf_ml = conf_ml.replace('&quot;', '"').replace('&amp;', '&')
 
             html = html.replace(tag, conf_ml)
 
@@ -212,5 +210,3 @@ def add_contents(html):
 
     html = contents_markup + '\n' + html
     return html
-
-

--- a/md2conf.py
+++ b/md2conf.py
@@ -23,6 +23,7 @@ import urllib
 import webbrowser
 import requests
 import markdown
+import markdown2
 import convert
 
 from datetime import datetime
@@ -589,8 +590,7 @@ def main():
     LOGGER.info('Title:\t\t%s', title)
 
     with codecs.open(MARKDOWN_FILE, 'r', 'utf-8') as mdfile:
-        html = markdown.markdown(mdfile.read(), extensions=['markdown.extensions.tables',
-                                                       'markdown.extensions.fenced_code'])
+        html = markdown2.markdown(mdfile.read(), extras=["fenced-code-blocks"])
 
     html = '\n'.join(html.split('\n')[1:])
 


### PR DESCRIPTION
## changes
- Use https://github.com/trentm/python-markdown2 for parsing html to markdown.

The original `markdown` library https://python-markdown.github.io/ was a bit finicky when dealing with lists and code in lists so decided to give this library a try which was a lot better.

In particular, it was taking content like 

```
- some item here
- another item here

1. New list
2. New list item
```
and converting it to

```
- some item here
- another item here
- New list
- New list item
```

Instead of recognizing the separate lists

it was also having trouble with some code blocks...
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/h-wang94/md_to_conf/5)
<!-- Reviewable:end -->
